### PR TITLE
Add Options button to Song List interface

### DIFF
--- a/ChartPlayerShared/SongListInterface.cs
+++ b/ChartPlayerShared/SongListInterface.cs
@@ -185,6 +185,7 @@ namespace ChartPlayer
             buttonInputStack.AddInput(new DialogInput { Text = "Bass", Action = delegate { SetCurrentInstrument(ESongInstrumentType.BassGuitar); } });
             buttonInputStack.AddInput(new DialogInput { Text = "Drums", Action = delegate { SetCurrentInstrument(ESongInstrumentType.Drums); } });
             buttonInputStack.AddInput(new DialogInput { Text = "Keys", Action = delegate { SetCurrentInstrument(ESongInstrumentType.Keys); } });
+            buttonInputStack.AddInput(new DialogInput { Text = "Options", Action = delegate { SongPlayerInterface.Instance.ShowOptions(); } });
             buttonInputStack.AddInput(new DialogInput { Text = "ReScan", Action = delegate { SongPlayerInterface.Instance.RescanSongIndex(); } });
             buttonInputStack.AddInput(new DialogInput
             {

--- a/ChartPlayerShared/SongPlayerInterface.cs
+++ b/ChartPlayerShared/SongPlayerInterface.cs
@@ -527,6 +527,19 @@ namespace ChartPlayer
             songList.SetSongIndex(songIndex);
         }
 
+        public void ShowOptions()
+        {
+            ChartPlayerGame.Instance.Plugin.GameHost.IsMouseVisible = true;
+
+            if (songPlayer != null)
+            {
+                if (!songPlayer.Paused)
+                    TogglePaused();
+            }
+
+            Layout.Current.ShowPopup(settingsInterface);
+        }
+
         public SongPlayerSettings LoadDefaultOptions()
         {
             SongPlayerSettings settings = null;


### PR DESCRIPTION
## Summary
- Adds an "Options" button to the song list screen for easier access to settings
- Exposes settings dialog without needing to load a song first

Closes #38

## Changes
| File | Change |
|------|--------|
| `SongListInterface.cs` | Added "Options" button between "Keys" and "ReScan" |
| `SongPlayerInterface.cs` | Added public `ShowOptions()` method to expose settings dialog |

## Button Order (Song List)
`Lead` `Rhythm` `Bass` `Drums` `Keys` **`Options`** `ReScan` `?` `Close`

## Implementation Notes
- The `ShowOptions()` method mirrors the existing Options button behavior from the playback interface
- Pauses playback if a song is playing before showing the dialog
- Makes mouse cursor visible when opening settings